### PR TITLE
IPython notebook integration for pygg

### DIFF
--- a/pygg/pygg.py
+++ b/pygg/pygg.py
@@ -277,6 +277,33 @@ def ggsave(name, plot, data, *args, **kwargs):
     return prog
 
 
+def gg_ipython(plot, data, *args, **kwargs):
+    """Render pygg in an IPython notebook
+
+    Allows one to say things like:
+
+    import pygg
+    p = pygg.ggplot('diamonds', pygg.aes(x='carat', y='price', color='clarity'))
+    p += pygg.geom_point(alpha=0.5, size = 2)
+    p += pygg.scale_x_log10(limits=[1, 2])
+    pygg.gg_ipython(p, data=None, quiet=True)
+
+    directly in an IPython notebook and see the resulting ggplot2 image
+    displayed inline.  This function is print a warning if the IPython library
+    cannot be imported.  The ggplot2 image is rendered as a PNG and not
+    as a vectorized graphics object right now.
+
+    """
+    try:
+        import IPython.display
+        tmp_image_filename = tempfile.NamedTemporaryFile(suffix='.png').name
+        ggsave(name=tmp_image_filename, plot=plot, data=data, quiet=True,
+               *args, **kwargs)
+        return IPython.display.Image(filename=tmp_image_filename)
+    except ImportError:
+        print "Could't load IPython library; integration is disabled"
+
+
 def execute_r(prog, quiet):
     """Run the R code prog an R subprocess
 

--- a/pygg_ipython_integration.ipynb
+++ b/pygg_ipython_integration.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pygg\n",
+    "p = pygg.ggplot('diamonds', pygg.aes(x='carat', y='price', color='clarity'))\n",
+    "p += pygg.geom_point(alpha=0.5, size = 2)\n",
+    "p += pygg.scale_x_log10(limits=[1, 2])\n",
+    "pygg.gg_ipython(p, data=None, quiet=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/pygg_tests.py
+++ b/tests/pygg_tests.py
@@ -7,7 +7,23 @@ import os.path
 import pygg
 import pandas.util.testing as pdt
 
-# TODO -- test converting data.frame to R with proper escaping of types
+
+class IPythonTests(unittest.TestCase):
+    """Test IPython integration"""
+    def setUp(self):
+        """Setup IPython tests, skipping if IPython isn't present"""
+        try:
+            import IPython
+        except ImportError:
+            self.skipTest("Couldn't import IPython")
+    def testIPython(self):
+        """Test that gg_ipython returns a IPython png formatted image"""
+        p = pygg.ggplot('diamonds', pygg.aes(x='carat', y='price'))
+        p += pygg.geom_point()
+        img = pygg.gg_ipython(p, data=None)
+        self.assertIsNotNone(img.data)
+        self.assertEqual(img.format, "png")
+
 
 class TestUnits(unittest.TestCase):
     """Basic unit testing for pygg"""
@@ -140,17 +156,16 @@ class TestIntegration(unittest.TestCase):
         self.check_ggsave(p, None)
 
     def testFacets1(self):
-        p = pygg.ggplot('diamonds', pygg.aes(x='carat', y='price')) 
+        p = pygg.ggplot('diamonds', pygg.aes(x='carat', y='price'))
         p += pygg.geom_point()
         p += pygg.facet_grid("clarity~.")
         self.check_ggsave(p, None)
 
     def testFacets2(self):
-        p = pygg.ggplot('diamonds', pygg.aes(x='carat', y='price')) 
+        p = pygg.ggplot('diamonds', pygg.aes(x='carat', y='price'))
         p += pygg.geom_point()
         p += pygg.facet_wrap("~clarity")
         self.check_ggsave(p, None)
-
 
     def check_ggsave(self, plotobj, data, ext='.pdf'):
         tmpfile = tempfile.NamedTemporaryFile(suffix=ext).name


### PR DESCRIPTION
Adds easy rendering of pygg objects in an IPython notebook.  Note this code is only conditionally imported so the dependencies don't need to be updated for pygg in general. 
